### PR TITLE
Fix README example which does not compile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ package main
 import (
 	"fmt"
 	"log"
+
+	"github.com/edgelaboratories/interpolator"
 )
 
 func main() {
-	xys := XYs{
+	xys := interpolator.XYs{
 		{
 			X: 0.0,
 			Y: 1.2,
@@ -37,7 +39,7 @@ func main() {
 			Y: 1.4,
 		},
 	}
-	interp, err := NewGeometric(xys)
+	interp, err := interpolator.NewGeometric(xys)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Not a huge PR but I saw that the import of the module was missing in the README example.
So I just added it in order to make a compilable example.