### PR TITLE
Add Geometric Sqrt interpolator

### DIFF
--- a/geometric_sqrt.go
+++ b/geometric_sqrt.go
@@ -46,7 +46,7 @@ func (interp GeometricSqrt) Gradient(x float64) float64 {
 	if x <= p1.X || x >= p2.X {
 		return 0.0
 	}
-	H := p2.X - p1.X
-	lambda := math.Sqrt((x - p1.X) / H)
-	return 0.5 * math.Log(p2.Y/p1.Y) * math.Pow(p1.Y, (1.0-lambda)) * math.Pow(p2.Y, lambda) / (lambda * H)
+	h := p2.X - p1.X
+	lambda := math.Sqrt((x - p1.X) / h)
+	return 0.5 * math.Log(p2.Y/p1.Y) * math.Pow(p1.Y, (1.0-lambda)) * math.Pow(p2.Y, lambda) / (lambda * h)
 }

--- a/geometric_sqrt.go
+++ b/geometric_sqrt.go
@@ -46,6 +46,7 @@ func (interp GeometricSqrt) Gradient(x float64) float64 {
 	if x <= p1.X || x >= p2.X {
 		return 0.0
 	}
-	lambda := math.Sqrt((x - p1.X) / (p2.X - p1.X))
-	return 0.5 * math.Log(p2.Y/p1.Y) * interp.Value(x) / (lambda * (p2.X - p1.X))
+	H := p2.X - p1.X
+	lambda := math.Sqrt((x - p1.X) / H)
+	return 0.5 * math.Log(p2.Y/p1.Y) * math.Pow(p1.Y, (1.0-lambda)) * math.Pow(p2.Y, lambda) / (lambda * H)
 }

--- a/geometric_sqrt.go
+++ b/geometric_sqrt.go
@@ -1,0 +1,51 @@
+package interpolator
+
+import (
+	"fmt"
+	"math"
+)
+
+// GeometricSqrt is a geometric interpolator scaled with a square root.
+type GeometricSqrt struct {
+	xys XYs
+}
+
+// NewGeometricSqrt builds a geometric sqrt interpolator.
+// The input `xys` must be ordered, have unique abscissas
+// and positive ordinates.
+func NewGeometricSqrt(xys XYs) (*GeometricSqrt, error) {
+	if l := len(xys); l < 2 {
+		return nil, fmt.Errorf("at least 2 points are required to build a geometric sqrt interpolator, but got %d", l)
+	}
+	for _, xy := range xys {
+		if xy.Y < epsilon {
+			return nil, fmt.Errorf("input xys must have non-negative ordinates")
+		}
+	}
+	return &GeometricSqrt{
+		xys: xys,
+	}, nil
+}
+
+// Value compute the value of f(x) based on geometric sqrt interpolation with threshold.
+func (interp GeometricSqrt) Value(x float64) float64 {
+	p1, p2 := interp.xys.Interval(x)
+	if x <= p1.X {
+		return p1.Y
+	}
+	if x >= p2.X {
+		return p2.Y
+	}
+	lambda := math.Sqrt((x - p1.X) / (p2.X - p1.X))
+	return math.Pow(p1.Y, (1.0-lambda)) * math.Pow(p2.Y, lambda)
+}
+
+// Gradient computes the gradient of f(x) based on geometric sqrt interpolation.
+func (interp GeometricSqrt) Gradient(x float64) float64 {
+	p1, p2 := interp.xys.Interval(x)
+	if x <= p1.X || x >= p2.X {
+		return 0.0
+	}
+	lambda := math.Sqrt((x - p1.X) / (p2.X - p1.X))
+	return 0.5 * math.Log(p2.Y/p1.Y) * interp.Value(x) / (lambda * (p2.X - p1.X))
+}

--- a/geometric_sqrt.go
+++ b/geometric_sqrt.go
@@ -5,7 +5,7 @@ import (
 	"math"
 )
 
-// GeometricSqrt is a geometric interpolator scaled with a square root.
+// GeometricSqrt performs a geometric interpolation with respect to the square root of the abscissae
 type GeometricSqrt struct {
 	xys XYs
 }
@@ -27,7 +27,7 @@ func NewGeometricSqrt(xys XYs) (*GeometricSqrt, error) {
 	}, nil
 }
 
-// Value compute the value of f(x) based on geometric sqrt interpolation with threshold.
+// Value compute the value of f(x) based on geometric sqrt interpolation with flat extrapolation.
 func (interp GeometricSqrt) Value(x float64) float64 {
 	p1, p2 := interp.xys.Interval(x)
 	if x <= p1.X {

--- a/geometric_sqrt_test.go
+++ b/geometric_sqrt_test.go
@@ -1,0 +1,237 @@
+package interpolator
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testExpSqrtXYs = XYs{
+	{
+		X: 0.0,
+		Y: math.Exp(0.0),
+	},
+	{
+		X: 0.5,
+		Y: math.Exp(math.Sqrt(0.5)),
+	},
+	{
+		X: 1.0,
+		Y: math.Exp(2.0 * math.Sqrt(0.5)),
+	},
+	{
+		X: 1.5,
+		Y: math.Exp(3.0 * math.Sqrt(0.5)),
+	},
+	{
+		X: 2.0,
+		Y: math.Exp(4.0 * math.Sqrt(0.5)),
+	},
+}
+
+func TestNewGeometricSqrt(t *testing.T) {
+	_, err := NewGeometricSqrt(testLinearXYs)
+	assert.NoError(t, err)
+}
+
+func TestNewGeometricSqrtEmptyXYs(t *testing.T) {
+	_, err := NewGeometricSqrt(XYs{})
+	assert.Error(t, err)
+}
+
+func TestNewGeometricSqrtInsufficientXYs(t *testing.T) {
+	_, err := NewGeometricSqrt(XYs{
+		{
+			X: 0.0,
+			Y: 1.0,
+		},
+	})
+	assert.Error(t, err)
+}
+
+func TestNewGeometricSqrtInvalidXYs(t *testing.T) {
+	_, err := NewGeometricSqrt(XYs{
+		{
+			X: 0.0,
+			Y: epsilon / 2.0,
+		},
+		{
+			X: 1.0,
+			Y: 1.0,
+		},
+	})
+	assert.Error(t, err)
+}
+
+func TestGeometricSqrtValue(t *testing.T) {
+	tolerance := 1.0e-8
+	interpolator, err := NewGeometricSqrt(testExpSqrtXYs)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name     string
+		input    float64
+		expected float64
+	}{
+		{
+			"LeftExtrapolation",
+			-1.0,
+			1.0,
+		},
+		{
+			"Interpolation1",
+			0.3,
+			math.Exp(math.Sqrt(0.3)),
+		},
+		{
+			"Interpolation2",
+			0.7,
+			math.Exp(math.Sqrt(0.2) + math.Sqrt(0.5)),
+		},
+		{
+			"Interpolation3",
+			1.2,
+			math.Exp(math.Sqrt(0.2) + 2.0*math.Sqrt(0.5)),
+		},
+		{
+			"Interpolation4",
+			1.6,
+			math.Exp(math.Sqrt(0.1) + 3.0*math.Sqrt(0.5)),
+		},
+		{
+			"RightExtrapolation",
+			6.0,
+			math.Exp(4.0 * math.Sqrt(0.5)),
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assert.InEpsilon(t, tc.expected, interpolator.Value(tc.input), tolerance)
+		})
+	}
+}
+
+func ExampleGeometricSqrt_Value() {
+	xys := XYs{
+		{
+			X: 0.0,
+			Y: 1.2,
+		},
+		{
+			X: 0.5,
+			Y: 1.0,
+		},
+		{
+			X: 1.0,
+			Y: 1.4,
+		},
+	}
+	interp, err := NewGeometricSqrt(xys)
+	if err != nil {
+		return
+	}
+	fmt.Printf("%0.4f\n", interp.Value(0.75))
+	// Output: 1.2686
+}
+
+func TestGeometricSqrtGradient(t *testing.T) {
+	tolerance := 1.0e-8
+	interpolator, err := NewGeometricSqrt(testExpSqrtXYs)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name     string
+		input    float64
+		expected float64
+	}{
+		{
+			"LeftExtrapolation",
+			-1.0,
+			0.0,
+		},
+		{
+			"Interpolation1",
+			0.3,
+			math.Sqrt(0.5) * math.Exp(math.Sqrt(0.3)) / math.Sqrt(0.3/0.5),
+		},
+		{
+			"Interpolation2",
+			0.7,
+			math.Sqrt(0.5) * (math.Exp(math.Sqrt(0.2) + math.Sqrt(0.5))) / math.Sqrt(0.2/0.5),
+		},
+		{
+			"Interpolation3",
+			1.2,
+			math.Sqrt(0.5) * (math.Exp(math.Sqrt(0.2) + 2.0*math.Sqrt(0.5))) / math.Sqrt(0.2/0.5),
+		},
+		{
+			"Interpolation4",
+			1.6,
+			math.Sqrt(0.5) * (math.Exp(math.Sqrt(0.1) + 3.0*math.Sqrt(0.5))) / math.Sqrt(0.1/0.5),
+		},
+		{
+			"RightExtrapolation",
+			6.0,
+			0.0,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assert.InDelta(t, tc.expected, interpolator.Gradient(tc.input), tolerance)
+		})
+	}
+}
+
+func ExampleGeometricSqrt_Gradient() {
+	xys := XYs{
+		{
+			X: 0.0,
+			Y: 1.2,
+		},
+		{
+			X: 0.5,
+			Y: 1.0,
+		},
+		{
+			X: 1.0,
+			Y: 1.4,
+		},
+	}
+	interp, err := NewGeometricSqrt(xys)
+	if err != nil {
+		return
+	}
+	fmt.Printf("%0.4f\n", interp.Gradient(0.75))
+	// Output: 0.6037
+}
+
+func BenchmarkGeometricSqrtValue(b *testing.B) {
+	interpolator, err := NewGeometricSqrt(testExpSqrtXYs)
+	require.NoError(b, err)
+	var (
+		x = 0.7
+		y = math.Exp(math.Sqrt(0.2) + math.Sqrt(0.5))
+	)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		assert.InDelta(b, y, interpolator.Value(x), 1.0e-8)
+	}
+}
+
+func BenchmarkGeometricSqrtDerivative(b *testing.B) {
+	interpolator, err := NewGeometricSqrt(testExpSqrtXYs)
+	require.NoError(b, err)
+	var (
+		x = 0.7
+		y = math.Sqrt(0.5) * (math.Exp(math.Sqrt(0.2) + math.Sqrt(0.5))) / math.Sqrt(0.2/0.5)
+	)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		assert.InDelta(b, y, interpolator.Gradient(x), 1.0e-8)
+	}
+}


### PR DESCRIPTION
Comparison between 2 benchmarks : 

With geometric interpolation
```
BenchmarkGeometricValue-8   	  864538	      1352 ns/op	     232 B/op	       4 allocs/op
```

With geometric sqrt interpolation
```
BenchmarkGeometricSqrtValue-8   	  813078	      1528 ns/op	     232 B/op	       4 allocs/op
```

But be careful, results are not very stable