### PR TITLE
Correct piecewise constant interpolator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,6 @@ build:
 
 .PHONY: test
 test:
-	GO111MODULE=on go test -race ./...
+	mkdir -p bin
+	go test -tags=integration --race -coverprofile=bin/cover.out ./...
+	go tool cover -html=bin/cover.out -o bin/cover.html

--- a/piecewise_constant.go
+++ b/piecewise_constant.go
@@ -20,6 +20,9 @@ func NewPiecewiseConstant(xys XYs) (*PiecewiseConstant, error) {
 
 // Value compute the value of f(x) based on piecewise constant interpolation.
 func (interp PiecewiseConstant) Value(x float64) float64 {
+	if n := len(interp.xys); n == 1 {
+		return interp.xys[n-1].Y
+	}
 	p1, p2 := interp.xys.Interval(x)
 	if x < p2.X {
 		return p1.Y

--- a/piecewise_constant_test.go
+++ b/piecewise_constant_test.go
@@ -26,9 +26,14 @@ func TestPiecewiseConstantValue_SinglePoint(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
+
 	assert.Equal(t, 0.0, interpolator.Value(-1.0))
 	assert.Equal(t, 0.0, interpolator.Value(0.0))
 	assert.Equal(t, 0.0, interpolator.Value(1.0))
+
+	assert.Equal(t, 0.0, interpolator.Gradient(-1.0))
+	assert.Equal(t, 0.0, interpolator.Gradient(0.0))
+	assert.Equal(t, 0.0, interpolator.Gradient(1.0))
 }
 
 func TestPiecewiseConstantValue(t *testing.T) {

--- a/piecewise_constant_test.go
+++ b/piecewise_constant_test.go
@@ -18,6 +18,19 @@ func TestNewPiecewiseConstantEmptyXYs(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestPiecewiseConstantValue_SinglePoint(t *testing.T) {
+	interpolator, err := NewPiecewiseConstant(XYs{
+		{
+			X: 0.0,
+			Y: 0.0,
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 0.0, interpolator.Value(-1.0))
+	assert.Equal(t, 0.0, interpolator.Value(0.0))
+	assert.Equal(t, 0.0, interpolator.Value(1.0))
+}
+
 func TestPiecewiseConstantValue(t *testing.T) {
 	tolerance := 1.0e-8
 	interpolator, err := NewPiecewiseConstant(testLinearXYs)


### PR DESCRIPTION
Piecewise-constant Interpolators on single point are admitted, but the added test would panic on the current version.

This might be the fix to introduce in all other interpolators to get them to support single-point data.