### PR TITLE
Single point data as constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@
 
 ## Description
 
-Package `interpolator` provides univariate data interpolators.
+Package `interpolator` provides univariate data interpolators:
+
+* [piecewise-constant](piecewise_constant.go) interpolator
+* [piecewise-linear](piecewise_linear.go) interpolator
+* [piecewise-linear with threshold](piecewise_linear_threshold.go): the interpolated value is truncated to the closest in the data range, when the input point is out of the data domain, in order to prevent extrapolation effects
+* [piecewise-geometric](geometric.go)
+* [piecewise-geometric on square-root factor](geometric_sqrt.go): the interpolated value depends on the square root of the normalized distance from data points
+
+The input data is specified by means of a nonempty [slice of two-dimensional points](xy.go) `XYs`. If a single data point is provided, the resulting interpolator **treats the input as a constant** for all abscissae.
 
 ## Installation
 

--- a/geometric.go
+++ b/geometric.go
@@ -18,8 +18,8 @@ type Geometric struct {
 // The input `xys` must be ordered, have unique abscissas
 // and positive ordinates.
 func NewGeometric(xys XYs) (*Geometric, error) {
-	if l := len(xys); l < 2 {
-		return nil, fmt.Errorf("at least 2 points are required to build a geometric interpolator, but got %d", l)
+	if l := len(xys); l < 1 {
+		return nil, fmt.Errorf("at least 1 points is required to build a geometric interpolator, but got %d", l)
 	}
 	for _, xy := range xys {
 		if xy.Y < epsilon {
@@ -33,6 +33,9 @@ func NewGeometric(xys XYs) (*Geometric, error) {
 
 // Value compute the value of f(x) based on geometric interpolation.
 func (interp Geometric) Value(x float64) float64 {
+	if n := len(interp.xys); n == 1 {
+		return interp.xys[0].Y
+	}
 	p1, p2 := interp.xys.Interval(x)
 	lambda := (x - p1.X) / (p2.X - p1.X)
 	return math.Pow(p1.Y, (1.0-lambda)) * math.Pow(p2.Y, lambda)
@@ -40,6 +43,9 @@ func (interp Geometric) Value(x float64) float64 {
 
 // Gradient computes the gradient of f(x) based on geometric interpolation.
 func (interp Geometric) Gradient(x float64) float64 {
+	if n := len(interp.xys); n == 1 {
+		return 0.0
+	}
 	p1, p2 := interp.xys.Interval(x)
 	return math.Log(p2.Y/p1.Y) * interp.Value(x) / (p2.X - p1.X)
 }

--- a/geometric_sqrt.go
+++ b/geometric_sqrt.go
@@ -14,8 +14,8 @@ type GeometricSqrt struct {
 // The input `xys` must be ordered, have unique abscissas
 // and positive ordinates.
 func NewGeometricSqrt(xys XYs) (*GeometricSqrt, error) {
-	if l := len(xys); l < 2 {
-		return nil, fmt.Errorf("at least 2 points are required to build a geometric sqrt interpolator, but got %d", l)
+	if l := len(xys); l < 1 {
+		return nil, fmt.Errorf("at least 1 points is required to build a geometric sqrt interpolator, but got %d", l)
 	}
 	for _, xy := range xys {
 		if xy.Y < epsilon {
@@ -29,6 +29,9 @@ func NewGeometricSqrt(xys XYs) (*GeometricSqrt, error) {
 
 // Value compute the value of f(x) based on geometric sqrt interpolation with flat extrapolation.
 func (interp GeometricSqrt) Value(x float64) float64 {
+	if n := len(interp.xys); n == 1 {
+		return interp.xys[0].Y
+	}
 	p1, p2 := interp.xys.Interval(x)
 	if x <= p1.X {
 		return p1.Y
@@ -42,6 +45,9 @@ func (interp GeometricSqrt) Value(x float64) float64 {
 
 // Gradient computes the gradient of f(x) based on geometric sqrt interpolation.
 func (interp GeometricSqrt) Gradient(x float64) float64 {
+	if n := len(interp.xys); n == 1 {
+		return 0.0
+	}
 	p1, p2 := interp.xys.Interval(x)
 	if x <= p1.X || x >= p2.X {
 		return 0.0

--- a/geometric_sqrt_test.go
+++ b/geometric_sqrt_test.go
@@ -42,14 +42,22 @@ func TestNewGeometricSqrtEmptyXYs(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestNewGeometricSqrtInsufficientXYs(t *testing.T) {
-	_, err := NewGeometricSqrt(XYs{
+func TestNewGeometricSqrtSinglePoint(t *testing.T) {
+	interpolator, err := NewGeometricSqrt(XYs{
 		{
 			X: 0.0,
 			Y: 1.0,
 		},
 	})
-	assert.Error(t, err)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1.0, interpolator.Value(-1.0))
+	assert.Equal(t, 1.0, interpolator.Value(0.0))
+	assert.Equal(t, 1.0, interpolator.Value(1.0))
+
+	assert.Equal(t, 0.0, interpolator.Gradient(-1.0))
+	assert.Equal(t, 0.0, interpolator.Gradient(0.0))
+	assert.Equal(t, 0.0, interpolator.Gradient(1.0))
 }
 
 func TestNewGeometricSqrtInvalidXYs(t *testing.T) {

--- a/geometric_test.go
+++ b/geometric_test.go
@@ -42,14 +42,22 @@ func TestNewGeometricEmptyXYs(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestNewGeometricInsufficientXYs(t *testing.T) {
-	_, err := NewGeometric(XYs{
+func TestNewGeometricSinglePoint(t *testing.T) {
+	interpolator, err := NewGeometric(XYs{
 		{
 			X: 0.0,
 			Y: 1.0,
 		},
 	})
-	assert.Error(t, err)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1.0, interpolator.Value(-1.0))
+	assert.Equal(t, 1.0, interpolator.Value(0.0))
+	assert.Equal(t, 1.0, interpolator.Value(1.0))
+
+	assert.Equal(t, 0.0, interpolator.Gradient(-1.0))
+	assert.Equal(t, 0.0, interpolator.Gradient(0.0))
+	assert.Equal(t, 0.0, interpolator.Gradient(1.0))
 }
 
 func TestNewGeometricInvalidXYs(t *testing.T) {

--- a/piecewise_constant.go
+++ b/piecewise_constant.go
@@ -21,6 +21,7 @@ func NewPiecewiseConstant(xys XYs) (*PiecewiseConstant, error) {
 // Value compute the value of f(x) based on piecewise constant interpolation.
 func (interp PiecewiseConstant) Value(x float64) float64 {
 	if n := len(interp.xys); n == 1 {
+		// In case a single data point is provided, assume a constant curve
 		return interp.xys[n-1].Y
 	}
 	p1, p2 := interp.xys.Interval(x)

--- a/piecewise_linear.go
+++ b/piecewise_linear.go
@@ -9,8 +9,8 @@ type PiecewiseLinear struct {
 
 // NewPiecewiseLinear builds a piecewise linear interpolator.
 func NewPiecewiseLinear(xys XYs) (*PiecewiseLinear, error) {
-	if l := len(xys); l < 2 {
-		return nil, fmt.Errorf("at least 2 points are required to build a piecewise linear interpolator, but got %d", l)
+	if l := len(xys); l < 1 {
+		return nil, fmt.Errorf("at least 1 points is required to build a piecewise linear interpolator, but got %d", l)
 	}
 	return &PiecewiseLinear{
 		xys: xys,
@@ -19,6 +19,9 @@ func NewPiecewiseLinear(xys XYs) (*PiecewiseLinear, error) {
 
 // Value compute the value of f(x) based on piecewise linear interpolation.
 func (interp PiecewiseLinear) Value(x float64) float64 {
+	if n := len(interp.xys); n == 1 {
+		return interp.xys[0].Y
+	}
 	p1, p2 := interp.xys.Interval(x)
 	lambda := (x - p1.X) / (p2.X - p1.X)
 	return p1.Y*(1.0-lambda) + p2.Y*lambda
@@ -26,6 +29,9 @@ func (interp PiecewiseLinear) Value(x float64) float64 {
 
 // Gradient computes the gradient of f(x) based on linear interpolation.
 func (interp PiecewiseLinear) Gradient(x float64) float64 {
+	if n := len(interp.xys); n == 1 {
+		return 0.0
+	}
 	p1, p2 := interp.xys.Interval(x)
 	return (p2.Y - p1.Y) / (p2.X - p1.X)
 }

--- a/piecewise_linear.go
+++ b/piecewise_linear.go
@@ -20,6 +20,7 @@ func NewPiecewiseLinear(xys XYs) (*PiecewiseLinear, error) {
 // Value compute the value of f(x) based on piecewise linear interpolation.
 func (interp PiecewiseLinear) Value(x float64) float64 {
 	if n := len(interp.xys); n == 1 {
+		// In case a single data point is provided, assume a constant curve
 		return interp.xys[0].Y
 	}
 	p1, p2 := interp.xys.Interval(x)
@@ -30,6 +31,7 @@ func (interp PiecewiseLinear) Value(x float64) float64 {
 // Gradient computes the gradient of f(x) based on linear interpolation.
 func (interp PiecewiseLinear) Gradient(x float64) float64 {
 	if n := len(interp.xys); n == 1 {
+		// In case a single data point is provided, assume a constant curve
 		return 0.0
 	}
 	p1, p2 := interp.xys.Interval(x)

--- a/piecewise_linear_sqrt.go
+++ b/piecewise_linear_sqrt.go
@@ -13,8 +13,8 @@ type PiecewiseLinearSqrt struct {
 // NewPiecewiseLinearSqrt builds a piecewise linear sqrt interpolator with flat extrapolation.
 // The input `xys` must be ordered and have unique abscissas.
 func NewPiecewiseLinearSqrt(xys XYs) (*PiecewiseLinearSqrt, error) {
-	if l := len(xys); l < 2 {
-		return nil, fmt.Errorf("at least 2 points are required to build a piecewise linear sqrt interpolator, but got %d", l)
+	if l := len(xys); l < 1 {
+		return nil, fmt.Errorf("at least 1 points is required to build a piecewise linear sqrt interpolator, but got %d", l)
 	}
 	return &PiecewiseLinearSqrt{
 		xys: xys,
@@ -23,6 +23,9 @@ func NewPiecewiseLinearSqrt(xys XYs) (*PiecewiseLinearSqrt, error) {
 
 // Value compute the value of f(x) based on piecewise linear interpolation with flat extrapolation.
 func (interp PiecewiseLinearSqrt) Value(x float64) float64 {
+	if n := len(interp.xys); n == 1 {
+		return interp.xys[0].Y
+	}
 	p1, p2 := interp.xys.Interval(x)
 	if x <= p1.X {
 		return p1.Y
@@ -36,6 +39,9 @@ func (interp PiecewiseLinearSqrt) Value(x float64) float64 {
 
 // Gradient computes the gradient of f(x) based on piecewise linear interpolation with flat extrapolation.
 func (interp PiecewiseLinearSqrt) Gradient(x float64) float64 {
+	if n := len(interp.xys); n == 1 {
+		return 0.0
+	}
 	p1, p2 := interp.xys.Interval(x)
 	if x <= p1.X || x >= p2.X {
 		return 0.0

--- a/piecewise_linear_sqrt.go
+++ b/piecewise_linear_sqrt.go
@@ -24,6 +24,7 @@ func NewPiecewiseLinearSqrt(xys XYs) (*PiecewiseLinearSqrt, error) {
 // Value compute the value of f(x) based on piecewise linear interpolation with flat extrapolation.
 func (interp PiecewiseLinearSqrt) Value(x float64) float64 {
 	if n := len(interp.xys); n == 1 {
+		// In case a single data point is provided, assume a constant curve
 		return interp.xys[0].Y
 	}
 	p1, p2 := interp.xys.Interval(x)
@@ -40,6 +41,7 @@ func (interp PiecewiseLinearSqrt) Value(x float64) float64 {
 // Gradient computes the gradient of f(x) based on piecewise linear interpolation with flat extrapolation.
 func (interp PiecewiseLinearSqrt) Gradient(x float64) float64 {
 	if n := len(interp.xys); n == 1 {
+		// In case a single data point is provided, assume a constant curve
 		return 0.0
 	}
 	p1, p2 := interp.xys.Interval(x)

--- a/piecewise_linear_sqrt_test.go
+++ b/piecewise_linear_sqrt_test.go
@@ -42,14 +42,22 @@ func TestNewPiecewiseLinearSqrtEmptyXYs(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestNewPiecewiseLinearSqrtInsufficientXYs(t *testing.T) {
-	_, err := NewPiecewiseLinearSqrt(XYs{
+func TestNewPiecewiseLinearSqrtSinglePoint(t *testing.T) {
+	interpolator, err := NewPiecewiseLinearSqrt(XYs{
 		{
 			X: 0.0,
 			Y: 1.0,
 		},
 	})
-	assert.Error(t, err)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1.0, interpolator.Value(-1.0))
+	assert.Equal(t, 1.0, interpolator.Value(0.0))
+	assert.Equal(t, 1.0, interpolator.Value(1.0))
+
+	assert.Equal(t, 0.0, interpolator.Gradient(-1.0))
+	assert.Equal(t, 0.0, interpolator.Gradient(0.0))
+	assert.Equal(t, 0.0, interpolator.Gradient(1.0))
 }
 
 func TestPiecewiseLinearSqrtValue(t *testing.T) {

--- a/piecewise_linear_test.go
+++ b/piecewise_linear_test.go
@@ -18,14 +18,22 @@ func TestNewPiecewiseLinearEmptyXYs(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestNewPiecewiseLinearInsufficientXYs(t *testing.T) {
-	_, err := NewPiecewiseLinear(XYs{
+func TestNewPiecewiseLinearSinglePoint(t *testing.T) {
+	interpolator, err := NewPiecewiseLinear(XYs{
 		{
 			X: 0.0,
 			Y: 1.0,
 		},
 	})
-	assert.Error(t, err)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1.0, interpolator.Value(-1.0))
+	assert.Equal(t, 1.0, interpolator.Value(0.0))
+	assert.Equal(t, 1.0, interpolator.Value(1.0))
+
+	assert.Equal(t, 0.0, interpolator.Gradient(-1.0))
+	assert.Equal(t, 0.0, interpolator.Gradient(0.0))
+	assert.Equal(t, 0.0, interpolator.Gradient(1.0))
 }
 
 func TestPiecewiseLinearValue(t *testing.T) {

--- a/piecewise_linear_threshold.go
+++ b/piecewise_linear_threshold.go
@@ -21,6 +21,7 @@ func NewPiecewiseLinearThreshold(xys XYs) (*PiecewiseLinearThreshold, error) {
 // Value compute the value of f(x) based on piecewise linear interpolation with flat extrapolation.
 func (interp PiecewiseLinearThreshold) Value(x float64) float64 {
 	if n := len(interp.xys); n == 1 {
+		// In case a single data point is provided, assume a constant curve
 		return interp.xys[0].Y
 	}
 	p1, p2 := interp.xys.Interval(x)
@@ -37,6 +38,7 @@ func (interp PiecewiseLinearThreshold) Value(x float64) float64 {
 // Gradient computes the gradient of f(x) based on piecewise linear interpolation with flat extrapolation.
 func (interp PiecewiseLinearThreshold) Gradient(x float64) float64 {
 	if n := len(interp.xys); n == 1 {
+		// In case a single data point is provided, assume a constant curve
 		return 0.0
 	}
 	p1, p2 := interp.xys.Interval(x)

--- a/piecewise_linear_threshold.go
+++ b/piecewise_linear_threshold.go
@@ -10,8 +10,8 @@ type PiecewiseLinearThreshold struct {
 // NewPiecewiseLinearThreshold builds a piecewise linear interpolator with flat extrapolation.
 // The input `xys` must be ordered and have unique abscissas.
 func NewPiecewiseLinearThreshold(xys XYs) (*PiecewiseLinearThreshold, error) {
-	if l := len(xys); l < 2 {
-		return nil, fmt.Errorf("at least 2 points are required to build a piecewise linear threshold interpolator, but got %d", l)
+	if l := len(xys); l < 1 {
+		return nil, fmt.Errorf("at least 1 points is required to build a piecewise linear threshold interpolator, but got %d", l)
 	}
 	return &PiecewiseLinearThreshold{
 		xys: xys,
@@ -20,6 +20,9 @@ func NewPiecewiseLinearThreshold(xys XYs) (*PiecewiseLinearThreshold, error) {
 
 // Value compute the value of f(x) based on piecewise linear interpolation with flat extrapolation.
 func (interp PiecewiseLinearThreshold) Value(x float64) float64 {
+	if n := len(interp.xys); n == 1 {
+		return interp.xys[0].Y
+	}
 	p1, p2 := interp.xys.Interval(x)
 	if x <= p1.X {
 		return p1.Y
@@ -33,6 +36,9 @@ func (interp PiecewiseLinearThreshold) Value(x float64) float64 {
 
 // Gradient computes the gradient of f(x) based on piecewise linear interpolation with flat extrapolation.
 func (interp PiecewiseLinearThreshold) Gradient(x float64) float64 {
+	if n := len(interp.xys); n == 1 {
+		return 0.0
+	}
 	p1, p2 := interp.xys.Interval(x)
 	if x <= p1.X || x >= p2.X {
 		return 0.0

--- a/piecewise_linear_threshold_test.go
+++ b/piecewise_linear_threshold_test.go
@@ -18,14 +18,22 @@ func TestNewPiecewiseLinearThresholdEmptyXYs(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestNewPiecewiseLinearThresholdInsufficientXYs(t *testing.T) {
-	_, err := NewPiecewiseLinearThreshold(XYs{
+func TestNewPiecewiseLinearThresholdSinglePoint(t *testing.T) {
+	interpolator, err := NewPiecewiseLinearThreshold(XYs{
 		{
 			X: 0.0,
 			Y: 1.0,
 		},
 	})
-	assert.Error(t, err)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1.0, interpolator.Value(-1.0))
+	assert.Equal(t, 1.0, interpolator.Value(0.0))
+	assert.Equal(t, 1.0, interpolator.Value(1.0))
+
+	assert.Equal(t, 0.0, interpolator.Gradient(-1.0))
+	assert.Equal(t, 0.0, interpolator.Gradient(0.0))
+	assert.Equal(t, 0.0, interpolator.Gradient(1.0))
 }
 
 func TestPiecewiseLinearThresholdValue(t *testing.T) {


### PR DESCRIPTION
Treat single-point data as constant:
* constant value equal to the only point's ordinate for all abscissae
* zero gradient
* complain only when there are no points

Also:
* add test coverage
* improve README