### PR TITLE
ci: remove testing against Go 1.12.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.13.x, 1.14.x, 1.15.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: build test
 
 .PHONY: build
 build:
-	GO111MODULE=on go build -race ./...
+	go build -race ./...
 
 .PHONY: test
 test:


### PR DESCRIPTION
There is no policy about  supporting old version of Go but I feel that Go 1.12 is old enough to let us stop supporting it.