### PR TITLE
build: upgrade Go installation

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.15.x
 
       - name: Update dependencies
-        run: go mod tidy -go=1.17
+        run: go mod tidy
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
 
       - name: Update dependencies
-        run: go mod tidy
+        run: go mod tidy -go=1.17
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.17.x
 
       - name: Update dependencies
         run: go mod tidy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.15.x, 1.16.x, 1.17.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x, 1.16.x]
+        go-version: [1.17.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,5 @@
 module github.com/edgelaboratories/interpolator
 
-go 1.17
+go 1.15
 
 require github.com/stretchr/testify v1.7.0
-
-require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
-)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/edgelaboratories/interpolator
 
-go 1.13
+go 1.17
 
 require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)


### PR DESCRIPTION
- Bump Go 1.15 in `go.mod`
- use Go 1.17 in setup action
- test against 1.15, 1.16 and 1.17