### PR TITLE
build(deps): upgrade workflows

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.4.0
 
       - name: Install Go
         uses: actions/setup-go@v2
@@ -14,9 +14,9 @@ jobs:
           go-version: 1.17.x
 
       - name: Update dependencies
-        run: go mod tidy
+        run: go mod tidy -go=1.17
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v1.37
+          version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,11 @@ jobs:
     strategy:
       matrix:
         go-version: [1.15.x, 1.16.x, 1.17.x]
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.4.0
 
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,11 @@ linters:
     - gomnd
     - lll
     - wsl
+    - interfacer
+    - scopelint
+    - golint
+    - maligned
+    - varnamelen
 
 issues:
   exclude-rules:


### PR DESCRIPTION
- upgrade workflows deps with latest version available
- remove `macos` builds
- tidy up `go.mod` with `-go=1.17`