### PR TITLE
build(test): upgrade Go and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: daily
       time: "04:00"
-    reviewers:
-      - antonioiubatti93
-    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x, 1.18.x]
+        go-version: [1.17.x, 1.18.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x]
+        go-version: [1.15.x, 1.16.x, 1.17.x, 1.18.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x]
+        go-version: [1.17.x, 1.18.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/edgelaboratories/interpolator
 
-go 1.15
+go 1.17
 
 require github.com/stretchr/testify v1.7.1
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)


### PR DESCRIPTION
## To do

- [x] Make sure the workflows pass
- [x] Confirm the least Go version 1.17 is enough or whether we should regress to a former one. FYI @vthiery what do you think?
- [x] **Missing** : update the [corresponding runners in `external-providers`](https://github.com/edgelaboratories/external-providers/blob/master/github/repo-interpolator.tf#L33)

## What

Modernize the dependencies ecosystem:
- update Github actions
- upgrade Go to 1.17 and test for version >= 1.17