### PR TITLE
chore: update Go to 1.19

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.19.x
 
       - name: Update dependencies
-        run: go mod tidy -go=1.17
+        run: go mod tidy
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.17.x, 1.18.x, 1.19.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x]
+        go-version: [1.19.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x, 1.19.x]
+        go-version: [1.19.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,22 @@ linters:
     - golint
     - maligned
     - varnamelen
+    # Deprecated
+    - exhaustivestruct
+    - scopelint
+    - golint
+    - gomoddirectives
+    - interfacer
+    - maligned
+    - varcheck
+    - deadcode
+    - structcheck
+    - nosnakecase
+    - ifshort
+    # Disabled because of generics
+    - rowserrcheck
+    - sqlclosecheck
+    - wastedassign
 
 issues:
   exclude-rules:

--- a/doc.go
+++ b/doc.go
@@ -1,7 +1,5 @@
 /*
-
 Package interpolator provides interpolators to
 perform numerical interpolator for univariate data.
-
 */
 package interpolator

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgelaboratories/interpolator
 
-go 1.17
+go 1.19
 
 require github.com/stretchr/testify v1.7.5
 


### PR DESCRIPTION
- [x] remove old Go versions from runner after https://github.com/edgelaboratories/external-providers/pull/1171