### PR TITLE
chore(lint): update golangci lint 1.52.1 by pleasing revive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,7 @@ test:
 	mkdir -p bin
 	go test -tags=integration --race -coverprofile=bin/cover.out ./...
 	go tool cover -html=bin/cover.out -o bin/cover.html
+
+.PHONY: lint
+lint:
+	golangci-lint run ./...

--- a/piecewise_constant.go
+++ b/piecewise_constant.go
@@ -35,6 +35,6 @@ func (interp PiecewiseConstant) Value(x float64) float64 {
 }
 
 // Gradient computes the gradient of f(x) based on piecewise constant interpolation.
-func (interp PiecewiseConstant) Gradient(x float64) float64 {
+func (interp PiecewiseConstant) Gradient(float64) float64 {
 	return 0.0
 }


### PR DESCRIPTION
## Context

PRs in this repo are blocked due to golangci-lint release to v1.52.1.
This PR aims at pleasing `revive` to unblock the situation.

## Content

A single correction was needed in this repo.
I also added the `make lint` command.